### PR TITLE
Allow the author line in the footer to be overridden

### DIFF
--- a/layouts/erb/base.erb
+++ b/layouts/erb/base.erb
@@ -101,12 +101,16 @@
                 <li><a href="/cookies">Cookies</a></li>
                 <li><a href="/feedback">Feedback</a></li>
               <% end %>
-              <li>
-                Built by
-                <a href="https://mojdigital.blog.gov.uk/">
-                  <abbr title="Ministry of Justice">MOJ</abbr> Digital
-                </a>
-              </li>
+              <% if content_for? :author %>
+                <%= (defined? yield_content) ? yield_content(:author) : yield(:author) %>
+              <% else %>
+                <li>
+                  Built by
+                  <a href="https://mojdigital.blog.gov.uk/">
+                    <abbr title="Ministry of Justice">MOJ</abbr> Digital
+                  </a>
+                </li>
+              <% end %>
             </ul>
             <div class="open-government-licence">
               <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" class="ogl-logo">

--- a/layouts/generic-py-base.html
+++ b/layouts/generic-py-base.html
@@ -56,12 +56,14 @@
                 <li><a href="/cookies">Cookies</a></li>
                 <li><a href="/feedback">Feedback</a></li>
               {% endblock %}
-              <li>
-                Built by
-                <a href="https://mojdigital.blog.gov.uk/">
-                  <abbr title="Ministry of Justice">MOJ</abbr> Digital
-                </a>
-              </li>
+              {% block author %}
+                <li>
+                  Built by
+                  <a href="https://mojdigital.blog.gov.uk/">
+                    <abbr title="Ministry of Justice">MOJ</abbr> Digital
+                  </a>
+                </li>
+              {% endblock %}
             </ul>
             <div class="open-government-licence">
               <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" class="ogl-logo">

--- a/layouts/jade/base.jade
+++ b/layouts/jade/base.jade
@@ -33,12 +33,11 @@ html(lang='en' class='no-js')
         .global-subheader
           .container
             block global_subheader
-            
+
     main#content.main-content(role='main')
       .container
         block content
-          
-    
+
     footer.global-footer
       .container
         .support-links
@@ -49,15 +48,16 @@ html(lang='en' class='no-js')
                 li: a(href='/privacy') Privacy Policy
                 li: a(href='/cookies') Cookies
                 li: a(href='/feedback') Feedback
-              li: Built by <a href='https://mojdigital.blog.gov.uk/'><abbr title="Ministry of Justice">MOJ</abbr> Digital</a>
+              block author
+                li: Built by <a href='https://mojdigital.blog.gov.uk/'><abbr title="Ministry of Justice">MOJ</abbr> Digital</a>
             .open-government-licence
               a.ogl-logo(href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/') Open Government Licence
-              |  All content is available under the
+              |  All content is available under the #{''}
               a(href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/') Open Government Licence v3.0
               |  except where otherwise stated
         .copyright
           a(href='https://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm')© Crown copyright
-    
+
     block before_main_js
     block main_js
       script(src='javascripts/app.bundle.js')


### PR DESCRIPTION
This addition allows the author of the template, for example "MOJ Digital", to be overridden or completely removed if necessary. 

Fixes #9 
## Examples

For ERB templates:

``` erb
<% content_for :author do %>
  <li>
    Built by <a href="#">[Department name]</a>
  </li>
<% end %>
```

For Jinja/Django templates:

``` jinja
{% block author %}
  <li>
    Built by <a href="#">[Department name]</a>
  </li>
{% endblock %}
```

For Jade templates:

``` jade
block author
  li: Built by <a href='#'>[Department name]</a>
```
