### PR TITLE
Fix python templates markup to match documentation

### DIFF
--- a/layouts/django/external.html
+++ b/layouts/django/external.html
@@ -17,7 +17,6 @@
 {% block govuk_logo %}
   <div class="header-branding">
     <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" class="header-logo">
-      <img src="{% static 'images/crown-logo-black-2x.png' %}" alt="">
       <span>GOV.UK</span>
     </a>
   </div>

--- a/layouts/generic-py-base.html
+++ b/layouts/generic-py-base.html
@@ -31,10 +31,8 @@
         </div>
       </div>
       {% block global_subheader_container %}
-        <div class="global-subheader">
-          <div class="container">
-            {% block global_subheader %}{% endblock %}
-          </div>
+        <div class="global-subheader container">
+          {% block global_subheader %}{% endblock %}
         </div>
       {% endblock %}
     </header>


### PR DESCRIPTION
- the logo is already present in the background
- collapse 2 divs
